### PR TITLE
Apache allow restart

### DIFF
--- a/cookbooks/fb_apache/attributes/default.rb
+++ b/cookbooks/fb_apache/attributes/default.rb
@@ -185,3 +185,5 @@ default['fb_apache'] = {
   },
   'mpm' => 'prefork',
 }
+
+node.default['fb_apache']['allow_restart'] = true

--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -224,7 +224,13 @@ if node['platform_family'] == 'debian'
   end
 end
 
+service 'apache_enable' do
+  service_name svc
+  action [:enable]
+end
+
 service 'apache' do
   service_name svc
-  action [:enable, :start]
+  only_if { node['fb_apache']['allow_restart'] }
+  action [:nothing]
 end

--- a/cookbooks/fb_apache/templates/default/status.erb
+++ b/cookbooks/fb_apache/templates/default/status.erb
@@ -1,3 +1,11 @@
-<Location "<%= @location %>">
+<Location /server-status>
     SetHandler server-status
+    Require local
+    # vpn users
+    Require ip 10.96.244.0/22
+    # vpn users
+    Require ip 10.100.240.0/22
+    # GCP vpn users
+    Require ip 10.0.0.0/8
+    Require ip 127.0.0.1
 </Location>


### PR DESCRIPTION
<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->

## Description

We don't typically allow chef to restart apache. Adding some logic so we can prevent restarts/reloads if we don't want them. 

## Context / Why are we making this change?

> Please include details on why this change is necessary, and any applicable tickets, design docs, or documentation links.

## Testing and QA Plan

> How has this work been tested or QA'd?

## Impact

> What are the implications of these changes? Are there any cross-cutting concerns to keep in mind?
