### PR TITLE
Fb collectd

### DIFF
--- a/cookbooks/fb_collectd/recipes/default.rb
+++ b/cookbooks/fb_collectd/recipes/default.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-unless node.centos? || node.debian? || node.ubuntu?
-  fail 'fb_collectd is only supported on CentOS, Debian or Ubuntu.'
+unless node.centos? || node.rocky? || node.debian? || node.ubuntu?
+  fail 'fb_collectd is only supported on CentOS, Rocky, Debian or Ubuntu.'
 end
 
 case node['platform_family']

--- a/cookbooks/fb_collectd/recipes/default.rb
+++ b/cookbooks/fb_collectd/recipes/default.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-unless node.centos? || node.rocky? || node.debian? || node.ubuntu?
-  fail 'fb_collectd is only supported on CentOS, Rocky, Debian or Ubuntu.'
+unless node.rhel_family? || node.debian? || node.ubuntu?
+  fail 'fb_collectd is only supported on RHEL and family, Debian, or Ubuntu.'
 end
 
 case node['platform_family']

--- a/cookbooks/fb_collectd/recipes/frontend.rb
+++ b/cookbooks/fb_collectd/recipes/frontend.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-unless node.centos? || node.debian? || node.ubuntu?
-  fail 'fb_collectd is only supported on CentOS, Debian or Ubuntu.'
+unless node.centos? || node.rocky? || node.debian? || node.ubuntu?
+  fail 'fb_collectd is only supported on CentOS, Rocky, Debian or Ubuntu.'
 end
 
 case node['platform_family']

--- a/cookbooks/fb_collectd/recipes/frontend.rb
+++ b/cookbooks/fb_collectd/recipes/frontend.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-unless node.centos? || node.rocky? || node.debian? || node.ubuntu?
-  fail 'fb_collectd is only supported on CentOS, Rocky, Debian or Ubuntu.'
+unless node.rhel_family? || node.debian? || node.ubuntu?
+  fail 'fb_collectd is only supported on RHEL and family, Debian, or Ubuntu.'
 end
 
 case node['platform_family']


### PR DESCRIPTION
## Context / Why are we making this change?

So that we can run the fb_collectd cookbook against all RHEL-family hosts, including Rocky, and not just CentOS.
