### PR TITLE
make fb_apache work with ubuntu

### DIFF
--- a/cookbooks/fb_apache/attributes/default.rb
+++ b/cookbooks/fb_apache/attributes/default.rb
@@ -75,7 +75,7 @@ when 'rhel'
 when 'debian'
   {
     'htcacheclean_run' => 'auto',
-    'htcacheclean_mode' => 'daeon',
+    'htcacheclean_mode' => 'daemon',
     'htcacheclean_size' => '300M',
     'htcacheclean_daemon_interval' => '120',
     'htcacheclean_path' => '/var/cache/apache2/mod_cache_disk',

--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -244,6 +244,12 @@ if node['platform_family'] == 'debian'
     only_if { node['fb_apache']['enable_default_site'] }
     to '../sites-available/000-default.conf'
   end
+
+  %w{charset localized-error-pages other-vhosts-access-log security serve-cgi-bin}.each do |file|
+    file "#{confdir}/#{file}.conf" do
+      action :delete
+    end
+  end
 end
 
 service 'apache' do

--- a/cookbooks/fb_apache/recipes/default.rb
+++ b/cookbooks/fb_apache/recipes/default.rb
@@ -72,6 +72,11 @@ confdir =
     end
   end
 
+baseconfig = value_for_platform_family(
+ 'rhel' => "#{httpdir}/conf/httpd.conf",
+ 'debian' => "#{httpdir}/apache2.conf",
+)
+
 sitesdir = value_for_platform_family(
   'rhel' => confdir,
   'debian' => "#{httpdir}/sites-enabled",
@@ -163,7 +168,7 @@ fb_apache_cleanup_modules 'doit' do
   mod_dir moddir
 end
 
-template "#{httpdir}/conf/httpd.conf" do
+template "#{baseconfig}" do
   owner 'root'
   group 'root'
   mode '0644'

--- a/cookbooks/fb_apache/templates/default/apache2.conf.erb
+++ b/cookbooks/fb_apache/templates/default/apache2.conf.erb
@@ -1,0 +1,3 @@
+# This file is controlled by Chef, do not edit!
+
+<% FB::Apache.render_apache_conf(_buf, 0, node['fb_apache']['httpd_config']) %>


### PR DESCRIPTION
fb_apache's verify_configs function wouldn't work on ubuntu.  this PR addresses that and makes it work with both rhel and debian.