### PR TITLE
BOR-449: fb_apt: Add `apt_update_strace_path`

### DIFF
--- a/cookbooks/fb_apt/README.md
+++ b/cookbooks/fb_apt/README.md
@@ -23,6 +23,7 @@ Attributes
 * node['fb_apt']['preserve_unknown_keyrings']
 * node['fb_apt']['allow_modified_pkg_keyrings']
 * node['fb_apt']['apt_update_log_path']
+* node['fb_apt']['apt_update_strace_path']
 
 Usage
 -----
@@ -113,3 +114,10 @@ want to use Chef to upgrade across distros, however, you can set
 Set `node['fb_apt']['apt_update_log_path']` to log stdout and stderr of the
 `apt-get update` command invoked by this cookbook. This may be useful for
 debugging purposes. The caller must handle log rotation.
+
+Similarly, set `node['fb_apt']['apt_update_strace_path']` to capture strace
+output of the `apt-get update` command invoked by this cookbook. This may be
+useful for debugging purposes. Set `node['fb_apt']['apt_update_strace_flags']`
+to override the default strace flags (`-v -f -yy -Y -ttt -T -s4096 -A`). Note
+that by default, the log is appended to on each invocation. The caller must
+handle log rotation.

--- a/cookbooks/fb_apt/attributes/default.rb
+++ b/cookbooks/fb_apt/attributes/default.rb
@@ -39,6 +39,8 @@ default['fb_apt'] = {
   'preserve_unknown_keyrings' => false,
   'allow_modified_pkg_keyrings' => false,
   'apt_update_log_path' => nil,
+  'apt_update_strace_path' => nil,
+  'apt_update_strace_flags' => '-v -f -yy -Y -ttt -T -s4096 -A',
 }
 # fb_apt must be defined for this to work...
 keys = FB::Apt.get_official_keyids(node).map { |id| [id, nil] }.to_h

--- a/cookbooks/fb_apt/recipes/default.rb
+++ b/cookbooks/fb_apt/recipes/default.rb
@@ -98,8 +98,11 @@ end
 execute 'apt-get update' do
   command(lazy do
     log_path = node['fb_apt']['apt_update_log_path']
-    cmd_suffix = " >>#{Shellwords.shellescape(log_path)} 2>&1" if log_path
-    "apt-get update#{cmd_suffix}"
+    strace_path = node['fb_apt']['apt_update_strace_path']
+    strace_flags = node['fb_apt']['apt_update_strace_flags']
+    cmd_suffix = " >>#{log_path.shellescape} 2>&1" if log_path
+    cmd_prefix = "strace #{strace_flags} -o #{strace_path.shellescape} " if strace_path && ::File.exist?('/usr/bin/strace')
+    "#{cmd_prefix}apt-get update#{cmd_suffix}"
   end)
   action :nothing
 end


### PR DESCRIPTION
## Description

Add option to `fb_apt` to capture `strace` logs of `apt-get update` commands.

There is no intent to upstream this. We can revert after we (hopefully) smash this bug!

## Context / Why are we making this change?

Per our discussion today, because we haven't been able to reproduce this on 2 nodes running `apt update` in a loop, we're going to attempt to `strace` `apt-get update` in `fb_apt` on all nodes.

## Testing and QA Plan

`image-tool test`

## Impact

In this PR, none as it does nothing by default. In the follow-up PR, the impact will be some extra disk across all ChefNS nodes for the strace logs, slower Chef runs that run apt, and extra CPU for strace overhead.

