### PR TITLE
modify resolv-conf resource

### DIFF
--- a/cookbooks/fb_resolv/recipes/default.rb
+++ b/cookbooks/fb_resolv/recipes/default.rb
@@ -27,4 +27,6 @@ template '/etc/resolv.conf' do
   owner node.root_user
   group node.root_group
   mode '0644'
+  force_unlink true
+  manage_symlink_source false
 end


### PR DESCRIPTION
<!-- Need support on our inclusive code practices? Visit http://go/inclusivecode -->

## Description

Modify the resolve.conf template resource so that it removes the systemd-resolve managed symlink and creates a regular file.

## Context / Why are we making this change?

When chef attempts to update a template that's symlinked, it will update the source file instead of the file you intend to update.  

On Ubuntu, /etc/resolv.conf is symlinked to /run/systemd/resolve/stub-resolv.conf and managed by systemd-resolved. 
 Resolve.conf and systemd-resovled both attempt to update the same file, so it's safe to assume you shouldn't ever be using both at the same time.  If you use resolve.conf, we want to remove this symlink and treat resolv.conf as a normal file. 
 
Both options (`force_unlink` and `manage_symlink_source`) seem to be needed based on this bug report: https://github.com/chef/chef/issues/4992

## Testing and QA Plan

Images build and function correctly with these additional options added to the template resource.
