### PR TITLE
revert: "modify resolv-conf resource (#27)"

### DIFF
--- a/cookbooks/fb_resolv/recipes/default.rb
+++ b/cookbooks/fb_resolv/recipes/default.rb
@@ -27,6 +27,4 @@ template '/etc/resolv.conf' do
   owner node.root_user
   group node.root_group
   mode '0644'
-  force_unlink true
-  manage_symlink_source false
 end


### PR DESCRIPTION
Per @kornface13, this is no longer necessary - reverting so I can pull in https://github.com/etsy/chef-cookbooks/pull/28. 

This reverts commit ec07a0eab2fde5709ed922ae09200f088626f790, reversing changes made to b774201aed669ef2a141ce9e0cf6cc5e35cb04b8.
