### PR TITLE
fb_ssh: ensure /run/sshd exists before sshd_config verify

### DIFF
--- a/cookbooks/fb_ssh/recipes/default.rb
+++ b/cookbooks/fb_ssh/recipes/default.rb
@@ -89,6 +89,20 @@ Dir.glob(::File.join(FB::SSH.confdir(node), '*key')).each do |f|
   end
 end
 
+# On Debian-family systems, openssh 9.6+ checks for /run/sshd even in config-test
+# (-t) mode. When the openssh packages above are upgraded, dpkg post-install scripts
+# restart sshd asynchronously via deb-systemd-invoke, causing systemd to briefly
+# remove /run/sshd (a RuntimeDirectory, cleaned up on service stop). By the time
+# this resource runs, the stop phase has completed. Ensure the directory exists so
+# the sshd_config template verify below succeeds.
+# See: https://github.com/facebook/chef-cookbooks/pull/58
+directory '/run/sshd' do
+  owner 'root'
+  group node.root_group
+  mode '0755'
+  not_if { node.windows? }
+end
+
 template ::File.join(FB::SSH.confdir(node), 'sshd_config') do
   source 'ssh_config.erb'
   unless node.windows?


### PR DESCRIPTION
## Summary

On Ubuntu 24.04, openssh 9.6p1 changed `sshd -t` (config-test mode) to require the privilege separation directory `/run/sshd` even when just testing configuration. This broke our Ubuntu 24.04 image builds starting Mar 16, 2026.

**Root cause:** When `fb_ssh` upgrades the openssh packages during a Chef run, the dpkg post-install scripts restart sshd asynchronously through systemd. Systemd removes `/run/sshd` (a `RuntimeDirectory`) when stopping sshd, and recreates it when starting. This creates a ~4-second window where `/run/sshd` doesn't exist. The `sshd_config` template verify (`sshd -t`) runs during this window and fails:

```
Proposed content for /etc/ssh/sshd_config failed verification /usr/sbin/sshd -t -f %{path}
STDERR: Missing privilege separation directory: /run/sshd
```

**Fix:** Add a `directory[/run/sshd]` resource directly before the `sshd_config` template. By the time Chef has executed the preceding resources (ruby_block, confdir directory, key file permissions), the sshd stop phase has already completed — so we're recreating the directory after the delete, not racing it.

This matches the approach discussed in https://github.com/facebook/chef-cookbooks/pull/58.

## Test plan

- [ ] Lint: `cookstyle cookbooks/fb_ssh/recipes/default.rb` — no offenses
- [ ] Ubuntu 24.04 image build succeeds (validated via etsy/chef-config CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)