### PR TITLE
Update GitHub Actions workflows from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,60 +1,10 @@
 name: Continuous Integration
+
 on:
   push:
     branches: [main]
   pull_request:
+
 jobs:
-  ruby:
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ['2.7', '3.0', '3.1']
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
-    - name: Run rspec
-      run: ./scripts/run_chefspec
-    - name: Run cookstyle
-      run: ./scripts/run_cookstyle
-  kitchen:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - centos-7
-          - centos-stream-8
-          - ubuntu-1804
-          - ubuntu-2004
-          - debian-9
-          - debian-10
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Install Chef
-      uses: actionshub/chef-install@2.0.4
-      with:
-        project: chef-workstation
-        version: 20.11.180
-    - name: Run Kitchen
-      uses: actionshub/test-kitchen@2.1.0
-      with:
-        suite: default
-        os: ${{ matrix.os }}
-      env:
-        CHEF_LICENSE: accept-no-persist
-        CHEF_VERSION: 16.18.0
-  shellcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Run Shellcheck
-        uses: ludeeus/action-shellcheck@2.0.0
+  ci:
+    uses: ./.github/workflows/reusable-ci.yml

--- a/.github/workflows/kitchen-tests.yml
+++ b/.github/workflows/kitchen-tests.yml
@@ -1,0 +1,15 @@
+name: Kitchen Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  kitchen:
+    strategy:
+      fail-fast: false
+    uses: ./.github/workflows/reusable-kitchen-tests.yml
+    with:
+      suite: default
+    secrets: inherit

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,0 +1,116 @@
+name: Reusable CI
+
+on:
+  workflow_call:
+    inputs:
+      universe:
+        description: 'Run in universe mode (checkout chef-cookbooks and copy upstream cookbooks)'
+        type: boolean
+        required: false
+        default: false
+      additional_ruby_versions:
+        description: 'JSON string array of additional Ruby versions to add to the matrix (e.g., ["3.2", "3.3"])'
+        required: false
+        type: string
+        default: '[]'
+
+jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      ruby_matrix_json: ${{ steps.generate_matrix.outputs.ruby_matrix_json }}
+    env:
+      BASE_RUBY_LIST: '["3.1", "3.3"]'
+    steps:
+      - name: Generate Ruby Version Matrix JSON
+        id: generate_matrix
+        run: |
+          if ! command -v jq &> /dev/null; then
+            echo "jq not found, installing..."
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+
+          COMBINED=$(jq -c -n \
+            --argjson base "${BASE_RUBY_LIST}" \
+            --argjson extra '${{ inputs.additional_ruby_versions }}' \
+            '$base + $extra | unique')
+
+          echo "ruby_matrix_json=$COMBINED" >> "$GITHUB_OUTPUT"
+          echo "Final Ruby matrix: $COMBINED"
+        shell: bash
+
+  ruby:
+    needs: prepare-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ${{ fromJSON(needs.prepare-matrix.outputs.ruby_matrix_json) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ inputs.universe && 'universe' || '.' }}
+
+      - name: Checkout chef-cookbooks (Universe Mode)
+        if: inputs.universe
+        uses: actions/checkout@v4
+        with:
+          repository: facebook/chef-cookbooks
+          path: chef-cookbooks
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Install dependencies
+        run: bundle install
+        working-directory: ${{ inputs.universe && 'chef-cookbooks' || '.' }}
+
+      - name: Run rspec
+        run: ./scripts/run_chefspec ${{ inputs.universe && '../universe' || '' }}
+        working-directory: ${{ inputs.universe && 'chef-cookbooks' || '.' }}
+
+      - name: Run cookstyle
+        run: ./scripts/run_cookstyle ${{ inputs.universe && '-C ../universe' || '' }}
+        working-directory: ${{ inputs.universe && 'chef-cookbooks' || '.' }}
+
+  mdl:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ inputs.universe && 'universe' || '.' }}
+
+      - name: Checkout chef-cookbooks (Universe Mode)
+        if: inputs.universe
+        uses: actions/checkout@v4
+        with:
+          repository: facebook/chef-cookbooks
+          path: chef-cookbooks
+
+      - name: Copy MDL config (Universe Mode)
+        if: inputs.universe
+        run: |-
+          # MDL action won't accept a working-path arg, so it runs from
+          # the base directory, so that's where we put the configs, and then
+          # we just tell it what path to check
+          cp chef-cookbooks/.mdl* .
+
+      - name: Run mdl
+        uses: actionshub/markdownlint@main
+        with:
+          path: ${{ inputs.universe && 'universe' || '.' }}
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+
+      - name: Run Shellcheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          working-directory: ${{ inputs.universe && 'universe' || '.' }}

--- a/.github/workflows/reusable-kitchen-tests.yml
+++ b/.github/workflows/reusable-kitchen-tests.yml
@@ -1,0 +1,110 @@
+name: Reusable Kitchen Tests
+
+on:
+  workflow_call:
+    inputs:
+      universe:
+        description: 'Run in universe mode (checkout chef-cookbooks and copy upstream cookbooks)'
+        type: boolean
+        required: false
+        default: false
+      suite:
+        description: 'Test Kitchen suites to run'
+        type: string
+        required: false
+        default: 'default'
+      additional_os_list: # Ensure this is present
+        description: 'JSON string array of additional OS platforms to add to the Test Kitchen matrix (e.g., ''["my-custom-os-1", "my-custom-os-2"]'').'
+        type: string
+        required: false
+        default: '[]'
+      kitchen_local_yaml:
+        type: string
+        required: false
+
+jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      os_matrix_json: ${{ steps.generate_matrix.outputs.os_matrix_json }}
+    env:
+      # fedora-41 requires DNF5
+      BASE_OS_LIST: '["centos-stream-9", "centos-stream-10", "ubuntu-2204", "ubuntu-2404", "debian-12", "fedora-40"]'
+    steps:
+      - name: Generate OS Matrix JSON
+        id: generate_matrix
+        run: |
+          # Ensure jq is available, or use a pre-installed action if needed. Most ubuntu-latest runners have it.
+          if ! command -v jq &> /dev/null
+          then
+              echo "jq could not be found, installing..."
+              sudo apt-get update && sudo apt-get install -y jq
+          fi
+          COMBINED_MATRIX_JSON=$(jq -c -n --argjson base '${{ env.BASE_OS_LIST }}' --argjson additional '${{ inputs.additional_os_list }}' '$base + $additional | unique')
+          echo "Generated OS Matrix JSON: $COMBINED_MATRIX_JSON"
+          echo "os_matrix_json=$COMBINED_MATRIX_JSON" >> $GITHUB_OUTPUT
+        shell: bash
+
+  run-kitchen-tests:
+    needs: [prepare-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ${{ fromJSON(needs.prepare-matrix.outputs.os_matrix_json) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+        with:
+          path: ${{ inputs.universe && 'universe' || '.' }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install Chef Workstation
+        uses: actionshub/chef-install@2.0.4
+        with:
+          project: chef-workstation
+          version: 25.2.1075
+
+      - name: Checkout chef-cookbooks (Universe Mode)
+        if: inputs.universe
+        uses: actions/checkout@v4
+        with:
+          repository: facebook/chef-cookbooks
+          path: chef-cookbooks
+
+      - name: Copy upstream cookbooks (Universe Mode)
+        if: inputs.universe
+        run: ./chef-cookbooks/scripts/copy_upstream_cookbooks
+
+      - name: Copy upstream kitchen config (Universe Mode)
+        if: inputs.universe
+        run: cp ./chef-cookbooks/.kitchen.yml ./universe
+
+      - name: Set KITCHEN_LOCAL_YAML Environment Variable
+        if: inputs.kitchen_local_yaml != '' && inputs.kitchen_local_yaml != null
+        run: echo "KITCHEN_LOCAL_YAML=${{ inputs.kitchen_local_yaml }}" >> $GITHUB_ENV
+        shell: bash
+
+        # the latest chef-workstation doesn't have a new-enough kitchen-dokken
+        # to handle breaking changes in docker 29.x, so upgrade it.
+      - name: Upgrade kitchen-dokken
+        run: chef gem install kitchen-dokken
+        env:
+          CHEF_LICENSE: accept-no-persist
+
+      - name: Run Kitchen
+        uses: actionshub/test-kitchen@main
+        with:
+          suite: ${{ inputs.suite }}
+          os: ${{ matrix.os }}
+          working-directory: ${{ inputs.universe && 'universe' || '.' }}
+        env:
+          CHEF_LICENSE: accept-no-persist
+          CHEF_VERSION: 18.6.14
+          # needed only because of the `chef gem ...` above, we can remove
+          # this once a new workstation release is out
+          PATH: /home/runner/.chef/gem/ruby/3.1.0/bin:${{ env.PATH }}

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,40 +6,53 @@ driver:
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 platforms:
-  - name: centos-7
+  - name: fedora-40
     driver:
-      image: dokken/centos-7
+      image: dokken/fedora-40
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        # stub out /etc/fstab for fb_fstab
+        - RUN touch /etc/fstab
+  - name: fedora-41
+    driver:
+      image: dokken/fedora-41
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        # stub out /etc/fstab for fb_fstab
+        - RUN touch /etc/fstab
+  - name: centos-stream-9
+    driver:
+      image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         # stub out /etc/fstab for fb_fstab
         - RUN touch /etc/fstab
         # enable EPEL (for stuff like hddtemp)
-        - RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-  - name: centos-stream-8
+        - RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+  - name: centos-stream-10
     driver:
-      image: dokken/centos-stream-8
+      image: dokken/centos-stream-10
       pid_one_command: /usr/lib/systemd/systemd
       intermediate_instructions:
         # stub out /etc/fstab for fb_fstab
         - RUN touch /etc/fstab
+        # mirrorlist.centos.org doesn't exist anymore, use baseurl
+        - RUN sed -i=.bak -e 's/^mirrorlist/#mirrorlist/g' -e 's!^#baseurl=http://mirror.centos.org/$contentdir/$stream!baseurl=https://vault.centos.org/$stream!g' /etc/yum.repos.d/*.repo
+        - RUN rm /etc/yum.repos.d/*.bak
         # enable EPEL (for stuff like hddtemp)
-        - RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-  - name: ubuntu-18.04
+        - RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+  - name: ubuntu-24.04
     driver:
-      image: dokken/ubuntu-18.04
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd
-  - name: ubuntu-20.04
+  - name: ubuntu-22.04
     driver:
-      image: dokken/ubuntu-20.04
+      image: dokken/ubuntu-22.04
       pid_one_command: /bin/systemd
-  - name: debian-9
+  - name: debian-12
     driver:
-      image: dokken/debian-9
-      pid_one_commmand: /bin/systemd
-  - name: debian-10
-    driver:
-      image: dokken/debian-10
-      pid_one_commmand: /bin/systemd
+      image: dokken/debian-12
+      pid_one_command: /bin/systemd
 
 provisioner:
   name: dokken


### PR DESCRIPTION
## Summary

Updates `.github/workflows/` to the latest versions from upstream. The existing workflows were failing.

- Replaces the monolithic `ci.yml` with a leaner version that delegates to a reusable workflow
- Adds `reusable-ci.yml`, `reusable-kitchen-tests.yml`, and `kitchen-tests.yml`

## Test plan

- [ ] GitHub Actions workflows pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)